### PR TITLE
Reduce loops to improve process speed

### DIFF
--- a/camelot/handlers.py
+++ b/camelot/handlers.py
@@ -10,7 +10,7 @@ from .parsers import Stream, Lattice
 from .utils import (
     TemporaryDirectory,
     get_page_layout,
-    get_text_objects,
+    get_char_and_text_objects,
     get_rotation,
     is_url,
     download_url,
@@ -120,9 +120,7 @@ class PDFHandler(object):
                 outfile.write(f)
             layout, dim = get_page_layout(fpath)
             # fix rotated PDF
-            chars = get_text_objects(layout, ltype="char")
-            horizontal_text = get_text_objects(layout, ltype="horizontal_text")
-            vertical_text = get_text_objects(layout, ltype="vertical_text")
+            chars, horizontal_text, vertical_text = get_char_and_text_objects(layout)
             rotation = get_rotation(chars, horizontal_text, vertical_text)
             if rotation != "":
                 fpath_new = "".join([froot.replace("page", "p"), "_rotated", fext])

--- a/camelot/parsers/base.py
+++ b/camelot/parsers/base.py
@@ -2,7 +2,7 @@
 
 import os
 
-from ..utils import get_page_layout, get_text_objects
+from ..utils import get_page_layout, get_image_and_text_objects
 
 
 class BaseParser(object):
@@ -12,9 +12,7 @@ class BaseParser(object):
         self.filename = filename
         self.layout_kwargs = layout_kwargs
         self.layout, self.dimensions = get_page_layout(filename, **layout_kwargs)
-        self.images = get_text_objects(self.layout, ltype="image")
-        self.horizontal_text = get_text_objects(self.layout, ltype="horizontal_text")
-        self.vertical_text = get_text_objects(self.layout, ltype="vertical_text")
+        self.images, self.horizontal_text, self.vertical_text = get_image_and_text_objects(self.layout)
         self.pdf_width, self.pdf_height = self.dimensions
         self.rootname, __ = os.path.splitext(self.filename)
         self.imagename = "".join([self.rootname, ".png"])

--- a/camelot/utils.py
+++ b/camelot/utils.py
@@ -936,3 +936,116 @@ def get_text_objects(layout, ltype="char", t=None):
     except AttributeError:
         pass
     return t
+
+
+def get_char_and_text_objects(layout: LTContainer) -> Tuple[
+    List[LTChar], List[LTTextLineHorizontal], List[LTTextLineVertical]]:
+    """Recursively parses pdf layout to get a list of
+    PDFMiner LTChar, LTTextLineHorizontal, LTTextLineVertical objects.
+
+    Parameters
+    ----------
+    layout : object
+        PDFMiner LTContainer object
+            ( LTPage, LTTextLineHorizontal, LTTextLineVertical).
+
+    Returns
+    -------
+    result : tuple
+        Include List of LTChar objects, list of LTTextLineHorizontal objects
+        and list of LTTextLineVertical objects
+
+    """
+
+    char = []
+    horizontal_text = []
+    vertical_text = []
+
+    try:
+        for _object in layout:
+            if isinstance(_object, LTChar):
+                char.append(_object)
+            elif isinstance(_object, LTTextLineHorizontal):
+                horizontal_text.append(_object)
+                child_char = get_char_objects(_object)
+                char.extend(child_char)
+            elif isinstance(_object, LTTextLineVertical):
+                vertical_text.append(_object)
+                child_char = get_char_objects(_object)
+                char.extend(child_char)
+            elif isinstance(_object, LTContainer):
+                child_char, child_horizontal_text, child_vertical_text = get_char_and_text_objects(_object)
+                char.extend(child_char)
+                horizontal_text.extend(child_horizontal_text)
+                vertical_text.extend(child_vertical_text)
+    except AttributeError:
+        pass
+    return char, horizontal_text, vertical_text
+
+
+def get_char_objects(layout: LTContainer) -> List[LTChar]:
+    """Recursively parses pdf layout to get a list of PDFMiner LTChar
+
+    Parameters
+    ----------
+    layout : object
+        PDFMiner LTContainer object.
+
+    Returns
+    -------
+    result : list
+        List of LTChar text objects.
+
+    """
+    char = []
+    try:
+        for _object in layout:
+            if isinstance(_object, LTChar):
+                char.append(_object)
+            elif isinstance(_object, LTContainer):
+                child_char = get_char_objects(_object)
+                char.extend(child_char)
+    except AttributeError:
+        pass
+    return char
+
+
+def get_image_and_text_objects(layout: LTContainer) -> Tuple[
+    List[LTImage], List[LTTextLineHorizontal], List[LTTextLineVertical]]:
+    """Recursively parses pdf layout to get a list of
+    PDFMiner LTImage, LTTextLineHorizontal, LTTextLineVertical objects.
+
+    Parameters
+    ----------
+    layout : object
+        PDFMiner LTContainer object
+            ( LTPage, LTTextLineHorizontal, LTTextLineVertical).
+
+    Returns
+    -------
+    result : tuple
+        Include List of LTImage objects, list of LTTextLineHorizontal objects
+        and list of LTTextLineVertical objects
+
+    """
+
+    image = []
+    horizontal_text = []
+    vertical_text = []
+
+    try:
+        for _object in layout:
+            if isinstance(_object, LTImage):
+                image.append(_object)
+            elif isinstance(_object, LTTextLineHorizontal):
+                horizontal_text.append(_object)
+            elif isinstance(_object, LTTextLineVertical):
+                vertical_text.append(_object)
+            elif isinstance(_object, LTContainer):
+                child_image, child_horizontal_text, child_vertical_text = get_char_and_text_objects(_object)
+                image.extend(child_image)
+                horizontal_text.extend(child_horizontal_text)
+                vertical_text.extend(child_vertical_text)
+    except AttributeError:
+        pass
+    return image, horizontal_text, vertical_text


### PR DESCRIPTION
Originally, Camelot scans 2 to 3 times for whole PDF objects on the page to get 1. Horizontal Texts, 2. Vertical texts, and 3. Images. 
This PR is to change it to one scan to get everything.
